### PR TITLE
Correct *.pem names to work with DOCKER_CERT_PATH

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -230,8 +230,8 @@ func cmdConfig(c *cli.Context) {
 
 	storeDir := store.Path
 	caCert := filepath.Join(storeDir, name, "ca.pem")
-	clientCert := filepath.Join(storeDir, name, "client.pem")
-	clientKey := filepath.Join(storeDir, name, "client-key.pem")
+	clientCert := filepath.Join(storeDir, name, "cert.pem")
+	clientKey := filepath.Join(storeDir, name, "key.pem")
 	machineUrl, err := host.GetURL()
 	if err != nil {
 		log.Fatalf("Error getting machine url: %s", err)

--- a/host.go
+++ b/host.go
@@ -129,8 +129,8 @@ func (h *Host) GenerateCertificates(serverIPs []string) error {
 		return fmt.Errorf("error generating server cert: %s", err)
 	}
 
-	clientCertPath := filepath.Join(h.storePath, "client.pem")
-	clientKeyPath := filepath.Join(h.storePath, "client-key.pem")
+	clientCertPath := filepath.Join(h.storePath, "cert.pem")
+	clientKeyPath := filepath.Join(h.storePath, "key.pem")
 	log.Debugf("generating client cert: %s", clientCertPath)
 	if err := utils.GenerateCert([]string{""}, clientCertPath, clientKeyPath, caCertPath, privateKeyPath, org, bits); err != nil {
 		return fmt.Errorf("error generating client cert: %s", err)


### PR DESCRIPTION
See https://github.com/docker/docker/blob/master/docker/docker.go#L22

This is how things currently work with b2d.

Signed-off-by: Nathan LeClaire nathan.leclaire@gmail.com
