### PR TITLE
keep global b2d iso cache when using custom b2d iso

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -182,7 +182,7 @@ func (d *Driver) Create() error {
 	if d.Boot2DockerURL != "" {
 		isoURL = d.Boot2DockerURL
 		log.Infof("Downloading %s from %s...", isoFilename, isoURL)
-		if err := b2dutils.DownloadISO(imgPath, isoFilename, isoURL); err != nil {
+		if err := b2dutils.DownloadISO(d.storePath, isoFilename, isoURL); err != nil {
 			return err
 		}
 	} else {
@@ -199,11 +199,11 @@ func (d *Driver) Create() error {
 				return err
 			}
 		}
-	}
 
-	isoDest := filepath.Join(d.storePath, isoFilename)
-	if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
-		return err
+		isoDest := filepath.Join(d.storePath, isoFilename)
+		if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
+			return err
+		}
 	}
 
 	log.Infof("Creating SSH key...")

--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -177,17 +177,14 @@ func (d *Driver) Create() error {
 		if err := os.Mkdir(imgPath, 0700); err != nil {
 			return err
 		}
-
 	}
 
 	if d.Boot2DockerURL != "" {
 		isoURL = d.Boot2DockerURL
 		log.Infof("Downloading %s from %s...", isoFilename, isoURL)
-		if err := b2dutils.DownloadISO(commonIsoPath, isoFilename, isoURL); err != nil {
+		if err := b2dutils.DownloadISO(imgPath, isoFilename, isoURL); err != nil {
 			return err
-
 		}
-
 	} else {
 		// todo: check latest release URL, download if it's new
 		// until then always use "latest"
@@ -202,11 +199,11 @@ func (d *Driver) Create() error {
 				return err
 			}
 		}
+	}
 
-		isoDest := filepath.Join(d.storePath, isoFilename)
-		if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
-			return err
-		}
+	isoDest := filepath.Join(d.storePath, isoFilename)
+	if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
+		return err
 	}
 
 	log.Infof("Creating SSH key...")

--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -216,7 +216,7 @@ func (d *Driver) Create() error {
 	if d.Boot2DockerURL != "" {
 		isoURL = d.Boot2DockerURL
 		log.Infof("Downloading boot2docker.iso from %s...", isoURL)
-		if err := b2dutils.DownloadISO(imgPath, isoFilename, isoURL); err != nil {
+		if err := b2dutils.DownloadISO(d.storePath, isoFilename, isoURL); err != nil {
 			return err
 		}
 	} else {
@@ -244,11 +244,11 @@ func (d *Driver) Create() error {
 				return err
 			}
 		}
-	}
 
-	isoDest := filepath.Join(d.storePath, isoFilename)
-	if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
-		return err
+		isoDest := filepath.Join(d.storePath, isoFilename)
+		if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
+			return err
+		}
 	}
 
 	log.Infof("Creating SSH key...")

--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -211,16 +211,14 @@ func (d *Driver) Create() error {
 		if err := os.Mkdir(imgPath, 0700); err != nil {
 			return err
 		}
-
 	}
 
 	if d.Boot2DockerURL != "" {
 		isoURL = d.Boot2DockerURL
 		log.Infof("Downloading boot2docker.iso from %s...", isoURL)
-		if err := b2dutils.DownloadISO(commonIsoPath, isoFilename, isoURL); err != nil {
+		if err := b2dutils.DownloadISO(imgPath, isoFilename, isoURL); err != nil {
 			return err
 		}
-
 	} else {
 		// TODO: until vmw tools are merged into b2d master
 		// we will use the iso from the vmware team.
@@ -246,10 +244,11 @@ func (d *Driver) Create() error {
 				return err
 			}
 		}
-		isoDest := filepath.Join(d.storePath, isoFilename)
-		if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
-			return err
-		}
+	}
+
+	isoDest := filepath.Join(d.storePath, isoFilename)
+	if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
+		return err
 	}
 
 	log.Infof("Creating SSH key...")

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -301,7 +301,7 @@ func (d *Driver) Create() error {
 	if d.Boot2DockerURL != "" {
 		isoURL = d.Boot2DockerURL
 		log.Infof("Downloading boot2docker.iso from %s...", isoURL)
-		if err := b2dutils.DownloadISO(imgPath, isoFilename, isoURL); err != nil {
+		if err := b2dutils.DownloadISO(d.storePath, isoFilename, isoURL); err != nil {
 			return err
 
 		}
@@ -334,14 +334,12 @@ func (d *Driver) Create() error {
 				return err
 
 			}
-
 		}
-	}
 
-	isoDest := filepath.Join(d.storePath, isoFilename)
-	if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
-		return err
-
+		isoDest := filepath.Join(d.storePath, isoFilename)
+		if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
+			return err
+		}
 	}
 
 	log.Infof("Generating SSH Keypair...")

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -301,7 +301,7 @@ func (d *Driver) Create() error {
 	if d.Boot2DockerURL != "" {
 		isoURL = d.Boot2DockerURL
 		log.Infof("Downloading boot2docker.iso from %s...", isoURL)
-		if err := b2dutils.DownloadISO(commonIsoPath, isoFilename, isoURL); err != nil {
+		if err := b2dutils.DownloadISO(imgPath, isoFilename, isoURL); err != nil {
 			return err
 
 		}
@@ -336,11 +336,11 @@ func (d *Driver) Create() error {
 			}
 
 		}
-		isoDest := filepath.Join(d.storePath, isoFilename)
-		if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
-			return err
+	}
 
-		}
+	isoDest := filepath.Join(d.storePath, isoFilename)
+	if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
+		return err
 
 	}
 

--- a/utils/b2d.go
+++ b/utils/b2d.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"time"
@@ -84,29 +85,46 @@ func (b *B2dUtils) GetLatestBoot2DockerReleaseURL() (string, error) {
 }
 
 // Download boot2docker ISO image for the given tag and save it at dest.
-func (b *B2dUtils) DownloadISO(dir, file, url string) error {
-	client := getClient()
-	rsp, err := client.Get(url)
-	if err != nil {
-		return err
+func (b *B2dUtils) DownloadISO(dir, file, isoUrl string) error {
+	u, err := url.Parse(isoUrl)
+	var src io.ReadCloser
+	if u.Scheme == "file" {
+		s, err := os.Open(u.Path)
+		if err != nil {
+			return err
+		}
+		src = s
+	} else {
+		client := getClient()
+		s, err := client.Get(isoUrl)
+		if err != nil {
+			return err
+		}
+		src = s.Body
 	}
-	defer rsp.Body.Close()
+
+	defer src.Close()
 
 	// Download to a temp file first then rename it to avoid partial download.
 	f, err := ioutil.TempFile(dir, file+".tmp")
 	if err != nil {
 		return err
 	}
+
 	defer os.Remove(f.Name())
-	if _, err := io.Copy(f, rsp.Body); err != nil {
+
+	if _, err := io.Copy(f, src); err != nil {
 		// TODO: display download progress?
 		return err
 	}
+
 	if err := f.Close(); err != nil {
 		return err
 	}
+
 	if err := os.Rename(f.Name(), filepath.Join(dir, file)); err != nil {
 		return err
 	}
+
 	return nil
 }


### PR DESCRIPTION
per #805 [(comment)](https://github.com/docker/machine/pull/805#issuecomment-85049090), use `d.storePath` to save custom b2d iso for vsphere, virtualbox and fusion drivers.
