### PR TITLE
keep global b2d iso cache when using custom b2d iso

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -182,7 +182,7 @@ func (d *Driver) Create() error {
 	if d.Boot2DockerURL != "" {
 		isoURL = d.Boot2DockerURL
 		log.Infof("Downloading %s from %s...", isoFilename, isoURL)
-		if err := b2dutils.DownloadISO(imgPath, isoFilename, isoURL); err != nil {
+		if err := b2dutils.DownloadISO(d.storePath, isoFilename, isoURL); err != nil {
 			return err
 		}
 	} else {
@@ -199,11 +199,11 @@ func (d *Driver) Create() error {
 				return err
 			}
 		}
-	}
 
-	isoDest := filepath.Join(d.storePath, isoFilename)
-	if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
-		return err
+		isoDest := filepath.Join(d.storePath, isoFilename)
+		if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
+			return err
+		}
 	}
 
 	log.Infof("Creating SSH key...")

--- a/drivers/vmwarefusion/fusion_darwin.go
+++ b/drivers/vmwarefusion/fusion_darwin.go
@@ -216,7 +216,7 @@ func (d *Driver) Create() error {
 	if d.Boot2DockerURL != "" {
 		isoURL = d.Boot2DockerURL
 		log.Infof("Downloading boot2docker.iso from %s...", isoURL)
-		if err := b2dutils.DownloadISO(imgPath, isoFilename, isoURL); err != nil {
+		if err := b2dutils.DownloadISO(d.storePath, isoFilename, isoURL); err != nil {
 			return err
 		}
 	} else {
@@ -244,11 +244,11 @@ func (d *Driver) Create() error {
 				return err
 			}
 		}
-	}
 
-	isoDest := filepath.Join(d.storePath, isoFilename)
-	if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
-		return err
+		isoDest := filepath.Join(d.storePath, isoFilename)
+		if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
+			return err
+		}
 	}
 
 	log.Infof("Creating SSH key...")

--- a/drivers/vmwarevsphere/vsphere.go
+++ b/drivers/vmwarevsphere/vsphere.go
@@ -301,7 +301,7 @@ func (d *Driver) Create() error {
 	if d.Boot2DockerURL != "" {
 		isoURL = d.Boot2DockerURL
 		log.Infof("Downloading boot2docker.iso from %s...", isoURL)
-		if err := b2dutils.DownloadISO(imgPath, isoFilename, isoURL); err != nil {
+		if err := b2dutils.DownloadISO(d.storePath, isoFilename, isoURL); err != nil {
 			return err
 
 		}
@@ -334,14 +334,12 @@ func (d *Driver) Create() error {
 				return err
 
 			}
-
 		}
-	}
 
-	isoDest := filepath.Join(d.storePath, isoFilename)
-	if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
-		return err
-
+		isoDest := filepath.Join(d.storePath, isoFilename)
+		if err := utils.CopyFile(commonIsoPath, isoDest); err != nil {
+			return err
+		}
 	}
 
 	log.Infof("Generating SSH Keypair...")


### PR DESCRIPTION
per #805 [(comment)](https://github.com/docker/machine/pull/805#issuecomment-85049090), use `d.storePath` to save custom b2d iso for vsphere, virtualbox and fusion drivers.
