### PR TITLE
refactor provisioning to allow rancher along with other oses

### DIFF
--- a/libmachine/provision/boot2docker.go
+++ b/libmachine/provision/boot2docker.go
@@ -137,3 +137,7 @@ func (provisioner *Boot2DockerProvisioner) SSHCommand(args ...string) (*exec.Cmd
 func (provisioner *Boot2DockerProvisioner) GetDriver() drivers.Driver {
 	return provisioner.Driver
 }
+
+func (provisioner *Boot2DockerProvisioner) GetDockerEnginerConfigCmd(engineOptions, engineOptionsPath string) (*exec.Cmd, error) {
+	return provisioner.SSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee -a %s", engineOptions, engineOptionsPath))
+}

--- a/libmachine/provision/provisioner.go
+++ b/libmachine/provision/provisioner.go
@@ -22,6 +22,9 @@ type Provisioner interface {
 	// Get the directory where the settings files for docker are to be found
 	GetDockerOptionsDir() string
 
+	// Get the Command to set the docker engine config
+	GetDockerEnginerConfigCmd(engineOptions, engineOptionsPath string) (*exec.Cmd, error)
+
 	// Run a package action e.g. install
 	Package(name string, action pkgaction.PackageAction) error
 

--- a/libmachine/provision/rancher.go
+++ b/libmachine/provision/rancher.go
@@ -205,3 +205,7 @@ func (provisioner *RancherProvisioner) SSHCommand(args ...string) (*exec.Cmd, er
 func (provisioner *RancherProvisioner) GetDriver() drivers.Driver {
 	return provisioner.Driver
 }
+
+func (provisioner *RancherProvisioner) GetDockerEnginerConfigCmd(engineOptions, engineOptionsPath string) (*exec.Cmd, error) {
+	return provisioner.SSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee %s", engineOptions, engineOptionsPath))
+}

--- a/libmachine/provision/ubuntu.go
+++ b/libmachine/provision/ubuntu.go
@@ -160,3 +160,7 @@ func (provisioner *UbuntuProvisioner) GenerateDockerOptions(dockerPort int, auth
 func (provisioner *UbuntuProvisioner) GetDriver() drivers.Driver {
 	return provisioner.Driver
 }
+
+func (provisioner *UbuntuProvisioner) GetDockerEnginerConfigCmd(engineOptions, engineOptionsPath string) (*exec.Cmd, error) {
+	return provisioner.SSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee -a %s", engineOptions, engineOptionsPath))
+}

--- a/libmachine/provision/utils.go
+++ b/libmachine/provision/utils.go
@@ -179,7 +179,7 @@ func ConfigureAuth(p Provisioner, authOptions auth.AuthOptions) error {
 		return err
 	}
 
-	cmd, err = p.SSHCommand(fmt.Sprintf("echo \"%s\" | sudo tee %s", dkrcfg.EngineOptions, dkrcfg.EngineOptionsPath))
+	cmd, err = p.GetDockerEnginerConfigCmd(dkrcfg.EngineOptions, dkrcfg.EngineOptionsPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I refactored the code to allow differences to exist between rancher and other OSes without affecting other OS provisioners

Also, The clever hack to create /etc/os-release (https://github.com/ehazlett/machine/blob/122d89d865fcbecb7811f214ea7acc9db86b6421/drivers/virtualbox/virtualbox.go#L431) is not required anymore. https://github.com/rancherio/os/commit/8788ef3dfabe05da2b0207eb5bb7396fb509fa15
